### PR TITLE
Build static binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM golang:alpine AS bucketsbuilder
 
+RUN apk add --no-cache musl-dev gcc
 WORKDIR /go/src/github.com/sellleon/buckets
 COPY main.go .
-RUN go build
+RUN go build -ldflags "-linkmode external -extldflags -static"
 
-FROM alpine:latest
+FROM scratch
 WORKDIR /app/
 COPY index.html .
 COPY --from=bucketsbuilder /go/src/github.com/sellleon/buckets/buckets .


### PR DESCRIPTION
Builds a static go binary, which makes it possible to create a container from scratch without any dependencies.